### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@cmu-eberly-center/p5": "^0.8.0",
     "@cmu-eberly-center/p5.play": "^1.2.0",
     "@cmu-eberly-center/p5.beaker": "github:zmineroff/p5.beaker",
-    "npm": "^6.5.0",
     "ify-loader": "^1.1.0"
   },
   "private": true


### PR DESCRIPTION

Hello zmineroff!

It seems like you have npm as one of your (dev-) dependency in biolab-activity-ph-protonation-beaker.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
